### PR TITLE
fix: Fixes release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           git config --local user.email "platform@basistheory.com"
           git config --local user.name "github-actions[bot]"
 
-          sed -i "s/\(val versionName = \)'[^']*'/\1'${{ steps.tag-version.outputs.new_tag }}'/g" lib/build.gradle.kts
+          sed -i 's/\(val versionName = \)"[^"]*"/\1"${{ steps.tag-version.outputs.new_tag }}"/g' lib/build.gradle.kts
           sed -i "s/\(android-elements:\)[^']*'/\1${{ steps.tag-version.outputs.new_tag }}'/g" README.md
 
           echo "${{ steps.tag-version.outputs.changelog }}" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,11 @@ jobs:
           git config --local user.email "platform@basistheory.com"
           git config --local user.name "github-actions[bot]"
 
-          sed -i "s/\(versionName = \)'[^']*'/\1'${{ steps.tag-version.outputs.new_tag }}'/g" lib/build.gradle
           sed -i "s/\(android-elements:\)[^']*'/\1${{ steps.tag-version.outputs.new_tag }}'/g" README.md
 
           echo "${{ steps.tag-version.outputs.changelog }}" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
 
-          git add CHANGELOG.md README.md lib/build.gradle
+          git add CHANGELOG.md README.md
           git commit -m "chore(release): updating version and changelog ${{ steps.tag-version.outputs.new_tag }} [skip ci]" || echo "Nothing to update"
 
       - name: Push changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,12 @@ jobs:
           git config --local user.email "platform@basistheory.com"
           git config --local user.name "github-actions[bot]"
 
+          sed -i "s/\(val versionName = \)'[^']*'/\1'${{ steps.tag-version.outputs.new_tag }}'/g" lib/build.gradle.kts
           sed -i "s/\(android-elements:\)[^']*'/\1${{ steps.tag-version.outputs.new_tag }}'/g" README.md
 
           echo "${{ steps.tag-version.outputs.changelog }}" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
 
-          git add CHANGELOG.md README.md
+          git add CHANGELOG.md README.md lib/build.gradle.kts
           git commit -m "chore(release): updating version and changelog ${{ steps.tag-version.outputs.new_tag }} [skip ci]" || echo "Nothing to update"
 
       - name: Push changes

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add this dependency to your project's build file:
   }
 
   dependencies {
-      implementation 'com.github.basis-theory:android-elements:0.1.1'
+      implementation 'com.github.basis-theory:android-elements:0.0.1'
   }
 ```
 

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -14,7 +14,8 @@ android {
     defaultConfig {
         minSdk = 21
 
-        buildConfigField("String", "VERSION_NAME", "\"${defaultConfig.versionName}\"")
+        val versionName = "0.0.1"
+        buildConfigField("String", "VERSION_NAME", "\"${versionName}\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Fixes release script by removing old release process from early versions of basistheory-android that was silently performing a no-op sed command on lib/build.gradle in the old repo

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
