### PR TITLE
fix(ENG-11542): use bt_semantic_release app token for release write-back

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
           app-id: ${{ vars.SEMANTIC_RELEASE_APP_ID }}
           private-key: ${{ secrets.SEMANTIC_RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
-          permission-contents: write
 
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,7 @@ jobs:
           app-id: ${{ vars.SEMANTIC_RELEASE_APP_ID }}
           private-key: ${{ secrets.SEMANTIC_RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
-          permission-issues: write
-          permission-pull-requests: write
+          permission-contents: write
 
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ jobs:
   tag:
     name: Tag repo
     runs-on: ubuntu-latest
+    environment: PROD
     steps:
       - name: Start Deploy Message
         uses: Basis-Theory/public-github-actions/deploy-slack-action@master
@@ -15,15 +16,26 @@ jobs:
           slack-api-token: ${{ secrets.SLACK_DUCKBOT_API_KEY }}
           channel: ${{ vars.SLACK_DUCKBOT_RELEASE_CHANNEL_ID }}
 
+      - name: Mint semantic-release app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.SEMANTIC_RELEASE_APP_ID }}
+          private-key: ${{ secrets.SEMANTIC_RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_SEMANTIC_RELEASE_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Bump version and push tag
         id: tag-version
-        uses: mathieudutour/github-tag-action@v6.0
+        uses: mathieudutour/github-tag-action@06382dcd483ebaea54d37e40ad576658a6c6ef73 # v6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: false
@@ -44,10 +56,10 @@ jobs:
           git commit -m "chore(release): updating version and changelog ${{ steps.tag-version.outputs.new_tag }} [skip ci]" || echo "Nothing to update"
 
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master
         if: ${{ steps.tag-version.outputs.release_type != '' }}
         with:
-          github_token: ${{ secrets.GH_SEMANTIC_RELEASE_PAT }}
+          github_token: ${{ steps.app-token.outputs.token }}
           branch: ${{ github.ref }}
 
       - name: Stop Deploy Message


### PR DESCRIPTION
## Description
Completes the semantic-release PAT → GitHub App migration for android-elements (missed by ENG-11425). The `release.yml` `tag` job used `GH_SEMANTIC_RELEASE_PAT` for the checkout and the master `[skip ci]` write-back push.

- `tag` job now declares `environment: PROD` (so the master-restricted `SEMANTIC_RELEASE_APP_PRIVATE_KEY` resolves).
- Mints a `bt_semantic_release` app token (`actions/create-github-app-token`, least-privilege `permission-contents/issues/pull-requests: write`) and uses it for both the checkout `token:` and the `ad-m/github-push-action` `github_token:`.
- `persist-credentials: false` on checkout; SHA-pinned the actions that receive the app token (`checkout`, `ad-m/github-push-action`) and the tag action.

**Paired with** github-repository-management#454, which provisions this repo's branch protection + `bt_semantic_release` bypass + the master-restricted prod-env app key.

### Rollout order (do not merge alone)
1. Apply github-repository-management#454.
2. Delete this repo's classic branch protection: `gh api -X DELETE repos/Basis-Theory/android-elements/branches/master/protection`.
3. Merge this PR.
4. Validate a real release (tag cut + `[skip ci]` write-back to master succeeds).

## Business Impact
- Minimal — removes a user-tied PAT from the release flow.

## Testing required outside of automated testing?
- [ ] Not Applicable — validate a real release end-to-end after the rollout steps above.

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Forward
- [ ] Roll Back

## Documentation
ENG-11542; pattern in github-repository-management docs/github-app-token-architecture.md.

## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change