### PR TITLE
chore(ENG-11054): pull java SDK from Maven Central instead of JitPack

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ activityCompose = "1.9.3"
 androidGifDrawable = "1.2.27"
 androidGradlePlugin = "8.9.1"
 appcompat = "1.7.0"
-basistheoryJava = "4.2.0"
+basistheoryJava = "7.0.3"
 commonsLang3 = "3.17.0"
 constraintlayout = "2.2.0"
 desugar_jdk_libs = "2.1.4"
@@ -23,7 +23,7 @@ compose = "1.7.6"
 material = "1.12.0"
 mockk = "1.13.8"
 navigationFragmentKtx = "2.8.5"
-okhttp = "4.11.0"
+okhttp = "5.2.1"
 robolectric = "4.13"
 striktCore = "0.34.1"
 threetenbp = "1.6.8"
@@ -51,7 +51,7 @@ androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx",
 androidx-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
 androidx-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
 androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
-basistheory-javaSdk = { module = "com.github.basis-theory:java-sdk", version.ref = "basistheoryJava" }
+basistheory-javaSdk = { module = "com.basistheory:api-client", version.ref = "basistheoryJava" }
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commonsLang3" }
 desugar_jdk_libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar_jdk_libs" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }

--- a/lib/src/main/java/com/basistheory/elements/service/BasisTheoryElements.kt
+++ b/lib/src/main/java/com/basistheory/elements/service/BasisTheoryElements.kt
@@ -16,7 +16,7 @@ import com.basistheory.elements.model.exceptions.EncryptTokenException
 import com.basistheory.elements.model.toAndroid
 import com.basistheory.elements.model.toJava
 import com.basistheory.types.CardDetailsResponse
-import com.basistheory.resources.enrichments.requests.EnrichmentsGetCardDetailsRequest
+import com.basistheory.resources.enrichments.requests.EnrichmentsCardDetailsRequest
 import com.basistheory.elements.util.JWEEncryption
 import com.basistheory.elements.util.getElementsValues
 import com.basistheory.elements.util.isPrimitiveType
@@ -214,10 +214,10 @@ class BasisTheoryElements internal constructor(
         try {
             withContext(dispatcher) {
                 val enrichmentsClient = apiClientProvider.getEnrichmentsApi(apiKeyOverride)
-                val request = EnrichmentsGetCardDetailsRequest.builder()
+                val request = EnrichmentsCardDetailsRequest.builder()
                     .bin(bin)
                     .build()
-                enrichmentsClient.getcarddetails(request)
+                enrichmentsClient.cardDetails(request)
             }
         } catch (e: com.basistheory.core.BasisTheoryApiApiException) {
             throw ApiException(e.statusCode(), e.headers(), e.body().toString(), e.message)

--- a/lib/src/test/java/com/basistheory/elements/service/BasisTheoryElementsTests.kt
+++ b/lib/src/test/java/com/basistheory/elements/service/BasisTheoryElementsTests.kt
@@ -485,7 +485,7 @@ class BasisTheoryElementsTests {
         val apiKeyOverride = UUID.randomUUID().toString()
 
         every { provider.getTokensApi(any()) } returns tokensApi
-        every { tokensApi.create(any()) } returns fakeToken()
+        every { tokensApi.create(any<com.basistheory.types.CreateTokenRequest>()) } returns fakeToken()
 
         bt.createToken(CreateTokenRequest(type = "token", data = ""), apiKeyOverride)
 
@@ -496,7 +496,7 @@ class BasisTheoryElementsTests {
     fun `createToken should forward top level primitive value without modification`() =
         runBlocking {
             every { provider.getTokensApi(any()) } returns tokensApi
-            every { tokensApi.create(any()) } returns fakeToken()
+            every { tokensApi.create(any<com.basistheory.types.CreateTokenRequest>()) } returns fakeToken()
 
             val name = faker.name().fullName()
             val createTokenRequest = createTokenRequest(name)
@@ -509,7 +509,7 @@ class BasisTheoryElementsTests {
     fun `createToken should forward complex data values within request without modification`() =
         runBlocking {
             every { provider.getTokensApi(any()) } returns tokensApi
-            every { tokensApi.create(any()) } returns fakeToken()
+            every { tokensApi.create(any<com.basistheory.types.CreateTokenRequest>()) } returns fakeToken()
 
             val data = object {
                 val string = faker.lorem().word()
@@ -558,7 +558,7 @@ class BasisTheoryElementsTests {
     fun `createToken should replace top level TextElement ref with underlying data value`() =
         runBlocking {
             every { provider.getTokensApi(any()) } returns tokensApi
-            every { tokensApi.create(any()) } returns fakeToken()
+            every { tokensApi.create(any<com.basistheory.types.CreateTokenRequest>()) } returns fakeToken()
 
             val name = faker.name().fullName()
             nameElement.setText(name)
@@ -576,7 +576,7 @@ class BasisTheoryElementsTests {
     fun `createToken should replace top level CardElement ref with underlying data value`() =
         runBlocking {
             every { provider.getTokensApi(any()) } returns tokensApi
-            every { tokensApi.create(any()) } returns fakeToken()
+            every { tokensApi.create(any<com.basistheory.types.CreateTokenRequest>()) } returns fakeToken()
 
             val cardNumber = testCardNumbers.random()
             cardNumberElement.setText(cardNumber)
@@ -594,7 +594,7 @@ class BasisTheoryElementsTests {
     fun `createToken should replace top level CardExpirationDateElement refs with underlying data value`() =
         runBlocking {
             every { provider.getTokensApi(any()) } returns tokensApi
-            every { tokensApi.create(any()) } returns fakeToken()
+            every { tokensApi.create(any<com.basistheory.types.CreateTokenRequest>()) } returns fakeToken()
 
             val expDate = LocalDate.now().plus(2, ChronoUnit.YEARS)
             val month = expDate.monthValue.toString().padStart(2, '0')
@@ -619,7 +619,7 @@ class BasisTheoryElementsTests {
     fun `createToken should replace Element refs within request object with underlying data values`() =
         runBlocking {
             every { provider.getTokensApi(any()) } returns tokensApi
-            every { tokensApi.create(any()) } returns fakeToken()
+            every { tokensApi.create(any<com.basistheory.types.CreateTokenRequest>()) } returns fakeToken()
 
             val name = faker.name().fullName()
             nameElement.setText(name)
@@ -696,7 +696,7 @@ class BasisTheoryElementsTests {
     fun `createToken should respect getValueType type when sending values to the API`() =
         runBlocking {
             every { provider.getTokensApi(any()) } returns tokensApi
-            every { tokensApi.create(any()) } returns fakeToken()
+            every { tokensApi.create(any<com.basistheory.types.CreateTokenRequest>()) } returns fakeToken()
 
 
             val testString = faker.name().firstName()
@@ -1112,7 +1112,7 @@ class BasisTheoryElementsTests {
                     )
                 }
 
-            verify { tokensApi.create(any()) wasNot Called }
+            verify { tokensApi.create(any<com.basistheory.types.CreateTokenRequest>()) wasNot Called }
         }
 
     @Test
@@ -1140,7 +1140,7 @@ class BasisTheoryElementsTests {
         runBlocking {
             every { provider.getTokensApi(any()) } returns tokensApi
 
-            every { tokensApi.create(any()) } throws com.basistheory.core.BasisTheoryApiApiException(
+            every { tokensApi.create(any<com.basistheory.types.CreateTokenRequest>()) } throws com.basistheory.core.BasisTheoryApiApiException(
                 "Api Error",
                 401,
                 ""
@@ -1529,7 +1529,7 @@ class BasisTheoryElementsTests {
         val tokenId = UUID.randomUUID().toString()
 
         every { provider.getTokensApi(any()) } returns tokensApi
-        every { tokensApi.update(any(), any()) } returns fakeToken()
+        every { tokensApi.update(any(), any<com.basistheory.resources.tokens.requests.UpdateTokenRequest>()) } returns fakeToken()
 
         bt.updateToken(tokenId, UpdateTokenRequest(data = ""), apiKeyOverride)
 
@@ -1540,7 +1540,7 @@ class BasisTheoryElementsTests {
     fun `updateToken should forward top level primitive value without modification`() =
         runBlocking {
             every { provider.getTokensApi(any()) } returns tokensApi
-            every { tokensApi.update(any(), any()) } returns fakeToken()
+            every { tokensApi.update(any(), any<com.basistheory.resources.tokens.requests.UpdateTokenRequest>()) } returns fakeToken()
 
             val tokenId = UUID.randomUUID().toString()
             val name = faker.name().fullName()
@@ -1554,7 +1554,7 @@ class BasisTheoryElementsTests {
     fun `updateToken should replace Element refs within request object with underlying data values`() =
         runBlocking {
             every { provider.getTokensApi(any()) } returns tokensApi
-            every { tokensApi.update(any(), any()) } returns fakeToken()
+            every { tokensApi.update(any(), any<com.basistheory.resources.tokens.requests.UpdateTokenRequest>()) } returns fakeToken()
 
             val tokenId = UUID.randomUUID().toString()
             val cvc = faker.random().nextInt(100, 999).toString()
@@ -1580,7 +1580,7 @@ class BasisTheoryElementsTests {
         runBlocking {
             every { provider.getTokensApi(any()) } returns tokensApi
 
-            every { tokensApi.update(any(), any()) } throws com.basistheory.core.BasisTheoryApiApiException(
+            every { tokensApi.update(any(), any<com.basistheory.resources.tokens.requests.UpdateTokenRequest>()) } throws com.basistheory.core.BasisTheoryApiApiException(
                 "Api Error",
                 401,
                 ""
@@ -1627,7 +1627,7 @@ class BasisTheoryElementsTests {
                 )
             }
 
-        verify { tokensApi.create(any()) wasNot Called }
+        verify { tokensApi.create(any<com.basistheory.types.CreateTokenRequest>()) wasNot Called }
     }
 
     private fun fakeToken(): com.basistheory.types.Token =

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven("https://jitpack.io")
     }
 }
 


### PR DESCRIPTION
## Description
- Switch the Basis Theory Java SDK dependency from JitPack (`com.github.basis-theory:java-sdk:4.2.0`) to Maven Central (`com.basistheory:api-client:7.0.3`) and remove the JitPack repository entirely — consumers no longer need it for transitive resolution
- Adapt to the v7 enrichments API rename: `EnrichmentsGetCardDetailsRequest` → `EnrichmentsCardDetailsRequest`, `getcarddetails()` → `cardDetails()`
- Bump OkHttp 4.11.0 → 5.2.1 to match the version strictly forced by api-client 7.0.3 (fixes MockWebServer incompatibility in tests)
- Add explicit type arguments to MockK matchers where new `create()`/`update()` overloads in v7 made untyped `any()` ambiguous

## Business Impact
- Minimal

## Testing required outside of automated testing?
- [ ] Not Applicable
- Full unit test suite passes (220 tests); recommend running acceptance tests (`./gradlew connectedCheck`) before release since the SDK jump spans three major versions (4.2.0 → 7.0.3)

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Forward
- [ ] Roll Back

## Documentation


## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change